### PR TITLE
Fix dropping cards

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,8 +88,8 @@ export default function createCah({
     return map;
   }, new Map());
 
-  function dropWhiteCard(card) {
-    state.whiteDeck.push(card);
+  function dropWhiteCard({ text }) {
+    state.whiteDeck.push(text);
   }
 
   /**


### PR DESCRIPTION
Decks are are stored as [String] where as user decks contain `{ id: String, text: String }`. We only want to append `text`.